### PR TITLE
feat: enable Greek letters for \mathbf using unicode-math

### DIFF
--- a/chapters/Ch_ExampleChapter.tex
+++ b/chapters/Ch_ExampleChapter.tex
@@ -38,9 +38,8 @@ As described in the sample page from ECE department, the style is set to \lstinl
   \item Mathbb letters: $\mathbb{A}$
   \item Mathfrak letters: $\mathfrak{A}$
   \item Math Sans serif letters: $\mathsf{A}$
-  \item Math bold letters: $\mathbf{A}$
-  \item Math bold upright Greek letters: $\mathbf{\alpha}$ (Not displaying! Use the following one.)
-  \item Math bold upright Greek letters: $\symbfup{\alpha}$
+  \item Math bold letters: $\mathbf{A, \alpha, \Sigma}$ \, (\lstinline|\mathbf|)
+  \item Math bold letters: $\symbfup{A, \alpha, \Sigma}$ \, (\lstinline|\symbfup|)
 \item Math bold italic Greek letters\footnote{Avoid using \lstinline|bm| package as it conflicts with \lstinline|unicode-math| and it is outdated for \hologo{XeLaTeX}. You can alias some math commands by \lstinline|\\newcommand| or \lstinline|\\renewcommand| anyway.}: $\bm{\alpha}$
   \item Math bold italic Greek letters in upper case: $\mathbi{A}$
 \end{itemize}

--- a/hkustthesis.dtx
+++ b/hkustthesis.dtx
@@ -1004,7 +1004,8 @@ keywords         .clist_set:N = \l_@@_info_keywords_clist,
 %    \begin{macrocode}
 \RequirePackage{amsmath,amsthm,mathtools,thmtools}
 \RequirePackage[
-  warnings-off={mathtools-colon,mathtools-overbracket}
+  warnings-off={mathtools-colon,mathtools-overbracket},
+  mathbf=sym
 ]{unicode-math}
 %    \end{macrocode}
 %


### PR DESCRIPTION
In unicode-math package, \mathbf does not work for Greek characters by default, which breaks manuscripts initially intended for other templates (e.g., IEEEconf.cls). This PR uses a builtin option of unicode-math to circumvent this issue. However, there are still some differences between the results of the new \mathbf and \symbfup, see some comparison in `chapters/Ch_ExampleChapter.tex`.

See [reference](https://tex.stackexchange.com/a/574664).